### PR TITLE
Fix wiki link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Pre-release version for testing.
 Developed by: Anatoly Spitkovsky, Luis Gargate, Jaehong Park, Lorenzo Sironi. 
 Based on original TRISTAN code by Oscar Buneman. 
 
-See http://ntoles.github.com/tristan-mp-pitp for more extensive documentation. 
+Refer to the [wiki](http://ntoles.github.io/tristan-mp-pitp) for more extensive documentation. 
 Warning: some of the info on the wiki is obsolete. 
 
 Organization and suggested workflow: 


### PR DESCRIPTION
Earlier the link pointed to a `*.github.com` which were deprecated for Github Pages. The proposed link points to the correct address.